### PR TITLE
Remove incorrect use of const

### DIFF
--- a/elf/data.hh
+++ b/elf/data.hh
@@ -553,7 +553,7 @@ struct Sym<Elf64, Order>
                 return (stb)(info >> 4);
         }
 
-        void set_binding(stb v) const
+        void set_binding(stb v)
         {
                 info = (info & 0xF) | ((unsigned char)v << 4);
         }


### PR DESCRIPTION
Found by compiling with clang++ instead of g++.
