### PR TITLE
Guard usage of `std::string::front` for empty string

### DIFF
--- a/dwarf/cursor.cc
+++ b/dwarf/cursor.cc
@@ -92,7 +92,9 @@ cursor::string(std::string &out)
         size_t size;
         const char *p = this->cstr(&size);
         out.resize(size);
-        memmove(&out.front(), p, size);
+        if (size > 0) {
+                memmove(&out.front(), p, size);
+        }
 }
 
 const char *


### PR DESCRIPTION
Fixes plasma-umass/coz#233.

This code uses `front()` to get the underlying string buffer. However,
when glibc++ assertions are enabled, this causes an assert failure if
the string is empty. Since we have no need to perform the memmove if the
string is empty, we can fix the crash by simply guarding with the
condition `size > 0`.

Note that this assert failure only occurred with glibc++ assertions
enabled. Because Arch apparently enables them by default (while other
distros don't), it initially appeared to be an Arch-specific problem.
However, it's just that it only surfaced on Arch, while having the
potential for issues on other platforms.
